### PR TITLE
Properly build regular expression with Pattern::inject()

### DIFF
--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -101,7 +101,7 @@ class Mapper{
             $model = substr( $model, 2 , strlen($model) );
             $model = "'".$model."'";
         }
-        return Pattern::of("\w*(?= *\( *\) *\{.*".$relationName."\( *\t*".$model.")");
+        return Pattern::inject("\w*(?= *\( *\) *\{.*@\( *\t*@)", [$relationName, $model]);
     }
 
     /**


### PR DESCRIPTION
`Pattern::inject()` is supposed to be used when injecting plain-test into regular expresions.