### PR TITLE
feat(model): eager load

### DIFF
--- a/adapters/vifrost-client/src/Model.ts
+++ b/adapters/vifrost-client/src/Model.ts
@@ -1,6 +1,9 @@
 import { client, getRegistry } from './config.js'
 import { QueryBuilder } from './QueryBuilder.js'
+import { buildQueryString, createQueryState } from './queryString.js'
 import type { ModelConstructor } from './types.js'
+
+const NO_INCLUDES: string[] = []
 
 /**
  * Base class generated `@vifrost/codegen` subclasses extend.
@@ -42,14 +45,32 @@ export class Model {
    * event can find and refresh it. Every fetch path (find/all/query/
    * relations) goes through this, so tracking is automatic whenever the
    * registry is in use, and entirely skipped otherwise.
+   *
+   * @param includes the `.with(...)` relations this row was originally
+   *   fetched with, if any — threaded through so the registered resync
+   *   function re-requests the same relations later, via the same
+   *   `query().with(...).whereId(id).first()` chain a caller would use
+   *   directly. Without this, a `Registry.resync()` triggered by a
+   *   real-time event would silently drop any eager-loaded relation: a
+   *   bare `find()` doesn't know to ask for it, and the resulting instance
+   *   falls back to exposing the relation-loader *method* itself (e.g.
+   *   `product.category`, a function) under the same property name, since
+   *   nothing overwrote it with data.
    */
-  static instantiate<T extends Model>(this: ModelConstructor<T>, attributes: Record<string, unknown>): T {
+  static instantiate<T extends Model>(
+    this: ModelConstructor<T>,
+    attributes: Record<string, unknown>,
+    includes: string[] = NO_INCLUDES
+  ): T {
     const instance = new this(attributes)
     const registry = getRegistry()
     const primaryKeyValue = attributes[this.primaryKey]
     if (registry && primaryKeyValue !== undefined && primaryKeyValue !== null) {
       registry.track(this.resource, primaryKeyValue as string | number, instance, () =>
-        this.find(primaryKeyValue as string | number)
+        this.query()
+          .with(...includes)
+          .whereId(primaryKeyValue as string | number)
+          .first() as Promise<T>
       )
     }
     return instance
@@ -68,11 +89,16 @@ export class Model {
   static query<T extends Model>(this: ModelConstructor<T>): QueryBuilder<T> {
     return new QueryBuilder<T>(
       this.resource,
-      async (path) => {
+      async (path, includes) => {
         const rows = await client().get<Record<string, unknown>[]>(path)
-        return rows.map((row) => this.instantiate(row))
+        return rows.map((row) => this.instantiate(row, includes))
       },
-      (id) => this.find(id),
+      async (id, includes) => {
+        const state = createQueryState()
+        state.includes = includes
+        const row = await client().get<Record<string, unknown>>(`${this.resource}/${id}${buildQueryString(state)}`)
+        return this.instantiate(row, includes)
+      },
       this.maxLimit
     )
   }

--- a/adapters/vifrost-client/src/QueryBuilder.ts
+++ b/adapters/vifrost-client/src/QueryBuilder.ts
@@ -18,8 +18,8 @@ export class QueryBuilder<T> {
 
   constructor(
     private readonly path: string,
-    private readonly fetchMany: (path: string) => Promise<T[]>,
-    private readonly fetchOne: (id: string | number) => Promise<T>,
+    private readonly fetchMany: (path: string, includes: string[]) => Promise<T[]>,
+    private readonly fetchOne: (id: string | number, includes: string[]) => Promise<T>,
     private readonly maxLimit: number | null
   ) {}
 
@@ -117,15 +117,15 @@ export class QueryBuilder<T> {
 
   async get(): Promise<T[]> {
     if (this.explicitId !== undefined) {
-      return [await this.fetchOne(this.explicitId)]
+      return [await this.fetchOne(this.explicitId, this.state.includes)]
     }
     this.assertWithinLimit()
-    return this.fetchMany(`${this.path}${this.toQueryString()}`)
+    return this.fetchMany(`${this.path}${this.toQueryString()}`, this.state.includes)
   }
 
   async first(): Promise<T | null> {
     if (this.explicitId !== undefined) {
-      return this.fetchOne(this.explicitId)
+      return this.fetchOne(this.explicitId, this.state.includes)
     }
     const results = await this.limit(1).get()
     return results[0] ?? null

--- a/adapters/vifrost-client/src/types.ts
+++ b/adapters/vifrost-client/src/types.ts
@@ -53,7 +53,7 @@ export interface ModelConstructor<T extends Model = Model> {
    * via the base `Model` class unless they opt in.
    */
   maxLimit: number | null
-  instantiate<R extends Model>(this: ModelConstructor<R>, data: Record<string, unknown>): R
+  instantiate<R extends Model>(this: ModelConstructor<R>, data: Record<string, unknown>, includes?: string[]): R
   find<R extends Model>(this: ModelConstructor<R>, id: string | number): Promise<R>
   query<R extends Model>(this: ModelConstructor<R>): QueryBuilder<R>
 }

--- a/adapters/vifrost-client/tests/Model.test.ts
+++ b/adapters/vifrost-client/tests/Model.test.ts
@@ -294,4 +294,27 @@ describe('Registry integration', () => {
     })
     expect(category.name).toBe('Widgets') // the OLD instance is untouched; the app swaps in the new one itself
   })
+
+  it('resync() replays the original .with() includes instead of dropping them', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 1, name: 'Gadget', category_id: 9, category: { id: 9, name: 'Widgets' } }])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 1, name: 'Gadget', category_id: 9, category: { id: 9, name: 'Widgets (renamed)' } }))
+
+    const [product] = await Product.query().with('category').limit(10).get()
+    expect(product.category).toEqual({ id: 9, name: 'Widgets' })
+
+    const listener = vi.fn()
+    registry.subscribe<Product>('product', 1, listener)
+
+    await registry.resync('product', 1)
+
+    const resyncUrl = fetchMock.mock.calls[1][0] as string
+    expect(resyncUrl).toContain('include=category')
+
+    const [event] = listener.mock.calls[0]
+    expect(typeof event.value.category).toBe('object')
+    expect(event.value.category).toEqual({ id: 9, name: 'Widgets (renamed)' })
+  })
 })


### PR DESCRIPTION
This is a change more for real time implementations, the idea behind is to eager load relationships already loaded in the JS model, this way i can ensure the front does not break for missing references